### PR TITLE
Code quality fix - Override annotation should be used on any method overriding

### DIFF
--- a/src/main/java/net/openhft/chronicle/network/VanillaSessionDetails.java
+++ b/src/main/java/net/openhft/chronicle/network/VanillaSessionDetails.java
@@ -126,18 +126,22 @@ public class VanillaSessionDetails implements SessionDetailsProvider {
         return (I) infoMap.get(infoClass);
     }
 
+    @Override
     public void setConnectTimeMS(long connectTimeMS) {
         this.connectTimeMS = connectTimeMS;
     }
 
+    @Override
     public void setClientAddress(InetSocketAddress clientAddress) {
         this.clientAddress = clientAddress;
     }
 
+    @Override
     public void setSecurityToken(String securityToken) {
         this.securityToken = securityToken;
     }
 
+    @Override
     public void setUserId(String userId) {
         this.userId = userId;
     }

--- a/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/WireTcpHandler.java
@@ -62,6 +62,7 @@ public abstract class WireTcpHandler implements TcpHandler {
         });
     }
 
+    @Override
     public void sendHeartBeat(Bytes out, SessionDetailsProvider sessionDetails) {
         if (out.writePosition() == 0) {
             final WireOut outWire = bytesToWire.apply(out);

--- a/src/main/java/net/openhft/chronicle/network/api/TcpHandler.java
+++ b/src/main/java/net/openhft/chronicle/network/api/TcpHandler.java
@@ -44,6 +44,7 @@ public interface TcpHandler extends ClientClosedProvider, Closeable {
     default void onEndOfConnection(boolean heartbeatTimeOut) {
     }
 
+    @Override
     default void close() {
     }
 

--- a/src/main/java/net/openhft/chronicle/network/connection/SocketAddressSupplier.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/SocketAddressSupplier.java
@@ -101,6 +101,7 @@ public class SocketAddressSupplier implements Supplier<SocketAddress> {
         return current.get();
     }
 
+    @Override
     @NotNull
     public String toString() {
 

--- a/src/main/java/net/openhft/chronicle/network/connection/TcpChannelHub.java
+++ b/src/main/java/net/openhft/chronicle/network/connection/TcpChannelHub.java
@@ -400,6 +400,7 @@ public class TcpChannelHub implements Closeable {
     /**
      * called when we are completed finished with using the TcpChannelHub
      */
+    @Override
     public void close() {
         if (closed)
             return;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule: 
squid:S1161	@Override annotation should be used on any method overriding

You can find more information about the issue here: 
http://dev.eclipse.org/sonar/rules/show/squid:S1161

Please let me know if you have any questions.

Faisal